### PR TITLE
Add JWT logout endpoint with refresh token blacklisting

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     'communications',
     'dashboard',
     'rest_framework',
+    'rest_framework_simplejwt.token_blacklist',
     'rest_framework.authtoken',
     'djoser',
 ]
@@ -57,8 +58,12 @@ REST_FRAMEWORK = {
 SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(minutes=30),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
+    'BLACKLIST_AFTER_ROTATION': True,
+    'ROTATE_REFRESH_TOKENS': True,
     'AUTH_HEADER_TYPES': ('Bearer',),
-    'AUTH_TOKEN_CLASSES': ('rest_framework_simplejwt.tokens.AccessToken',),
+    'AUTH_TOKEN_CLASSES': 
+    ('rest_framework_simplejwt.tokens.AccessToken'
+    'rest_framework_simplejwt.tokens.RefreshToken',),
 }
 
 DJOSER = {

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path, include
+from rest_framework_simplejwt.views import TokenBlacklistView
 
 urlpatterns = [
     path('auth/', include('djoser.urls')),
     path('auth/', include('djoser.urls.jwt')),
+    path('auth/jwt/logout/', TokenBlacklistView.as_view(), name='token_blacklist'),
 ]


### PR DESCRIPTION
## Changes
- Implemented `/auth/jwt/logout/` endpoint
- Configured token blacklist in settings

## Testing
1. Get a refresh token via login
2. Call `POST /auth/jwt/logout/` with the refresh token
3. Verify the token can no longer be used

## Screenshots

### 1. Successful Logout (200 OK)
![Successful Logout](https://github.com/user-attachments/assets/7922269c-e1ba-4c2e-a16c-65e02e1d6a22)

### 2. Token Blacklist Verification  
![Token Rejection](https://github.com/user-attachments/assets/1793803e-443f-4397-8147-007437d8f9e3)