### PR TITLE
Issue 37 Implement Notification Preference Settings

### DIFF
--- a/communications/models.py
+++ b/communications/models.py
@@ -33,6 +33,13 @@ class NotificationPriority(models.TextChoices):
     HIGH = 'high', _('High')
 
 
+class NotificationChannel(models.TextChoices):
+    """Channels for delivering notifications."""
+    IN_APP = 'in_app', _('In-App')
+    EMAIL = 'email', _('Email')
+    PUSH = 'push', _('Push')
+
+
 class NotificationType(TimeStampedModel):
     """Model to store different types of notifications."""
     code = models.SlugField(

--- a/communications/services.py
+++ b/communications/services.py
@@ -1,0 +1,121 @@
+import logging
+from typing import Optional
+
+from django.contrib.auth import get_user_model
+
+from .models import (
+    Notification,
+    NotificationType,
+    UserNotificationPreference,
+    UserNotificationTypePreference,
+    NotificationFrequency,
+    NotificationChannel,
+)
+
+logger = logging.getLogger(__name__)
+User = get_user_model()
+
+
+def _get_user_pref(user: User) -> Optional[UserNotificationPreference]:
+    try:
+        return user.notification_preferences
+    except UserNotificationPreference.DoesNotExist:
+        return None
+
+
+def get_or_create_user_pref(user: User) -> UserNotificationPreference:
+    """Return user's notification preferences, creating and seeding if absent.
+
+    Seeds per-type preferences for active NotificationType objects using
+    each type's default_frequency to avoid magic strings.
+    """
+    pref = _get_user_pref(user)
+    if pref:
+        return pref
+    pref = UserNotificationPreference.objects.create(user=user)
+    for ntype in NotificationType.objects.filter(is_active=True):
+        UserNotificationTypePreference.objects.create(
+            user_preference=pref,
+            notification_type=ntype,
+            frequency=ntype.default_frequency,
+        )
+    return pref
+
+
+def _get_type_pref(pref: UserNotificationPreference, ntype: NotificationType) -> Optional[UserNotificationTypePreference]:
+    return pref.type_preferences.filter(notification_type=ntype).first()
+
+
+def is_channel_enabled(user: User, channel: str) -> bool:
+    """Return whether a channel ("in_app", "email", "push") is enabled for user.
+    Falls back to True if preferences are missing (fail-open) to avoid blocking messages unintentionally.
+    """
+    pref = _get_user_pref(user)
+    if not pref:
+        return True
+    normalized = str(channel).lower()
+    if normalized in {NotificationChannel.IN_APP, "in-app", "inapp"}:
+        return bool(pref.enable_in_app)
+    if normalized == NotificationChannel.EMAIL:
+        return bool(pref.enable_email)
+    if normalized == NotificationChannel.PUSH:
+        return bool(pref.enable_push)
+    return True
+
+
+def is_type_allowed(user: User, ntype: NotificationType) -> bool:
+    """True if the specific notification type is not disabled for user."""
+    pref = _get_user_pref(user)
+    if not pref:
+        return True
+    type_pref = _get_type_pref(pref, ntype)
+    if not type_pref:
+        return True
+    return type_pref.frequency != NotificationFrequency.DISABLED
+
+
+def create_in_app_notification(
+    *,
+    user: User,
+    type_code: str,
+    title: str,
+    message: str,
+    priority: Optional[str] = None,
+    related_startup_id: Optional[int] = None,
+    related_project_id: Optional[int] = None,
+    related_message_id: Optional[int] = None,
+    triggered_by_user: Optional[User] = None,
+    triggered_by_type: Optional[str] = None,
+) -> Optional[Notification]:
+    """
+    Create an in-app Notification only if user's preferences allow it.
+    Returns the Notification instance or None if suppressed by preferences.
+    """
+    try:
+        ntype = NotificationType.objects.get(code=type_code)
+    except NotificationType.DoesNotExist:
+        logger.warning("Unknown notification type code: %s", type_code)
+        return None
+
+    if not is_channel_enabled(user, "in_app"):
+        logger.info("Suppressing in-app notification for user=%s (channel disabled)", getattr(user, "id", None))
+        return None
+    if not is_type_allowed(user, ntype):
+        logger.info(
+            "Suppressing in-app notification for user=%s type=%s (type disabled)",
+            getattr(user, "id", None), ntype.code,
+        )
+        return None
+
+    return Notification.objects.create(
+        user=user,
+        notification_type=ntype,
+        title=title,
+        message=message,
+        priority=priority or Notification._meta.get_field("priority").default,
+        related_startup_id=related_startup_id,
+        related_project_id=related_project_id,
+        related_message_id=related_message_id,
+        triggered_by_user=triggered_by_user,
+        triggered_by_type=triggered_by_type,
+    )

--- a/startups/views/startup.py
+++ b/startups/views/startup.py
@@ -1,10 +1,24 @@
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import SearchFilter
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework import status
 from startups.models import Startup
 from startups.serializers.startup_full import StartupSerializer
 from startups.views.startup_base import BaseValidatedModelViewSet
 from users.permissions import IsStartupUser
+from communications.models import (
+    UserNotificationPreference,
+    NotificationType,
+    UserNotificationTypePreference,
+)
+from communications.serializers import (
+    UserNotificationPreferenceSerializer,
+    UserNotificationTypePreferenceSerializer,
+    UpdateTypePreferenceSerializer,
+)
+from communications.services import get_or_create_user_pref
 
 
 class StartupViewSet(BaseValidatedModelViewSet):
@@ -15,3 +29,70 @@ class StartupViewSet(BaseValidatedModelViewSet):
     filter_backends = [DjangoFilterBackend, SearchFilter]
     filterset_fields = ['industry', 'stage', 'location__country']
     search_fields = ['company_name', 'user__first_name', 'user__last_name', 'email']
+
+    def _get_or_create_user_pref(self, request):
+        """Fetch the current user's notification preferences, creating defaults if absent.
+        Delegates to communications.services.get_or_create_user_pref to avoid duplication and
+        to seed type preferences using each NotificationType.default_frequency.
+        """
+        return get_or_create_user_pref(request.user)
+
+    @action(detail=False, methods=['get', 'patch'], url_path='preferences', url_name='preferences')
+    def preferences(self, request):
+        """Get or update the current startup user's notification channel preferences."""
+        pref = self._get_or_create_user_pref(request)
+
+        if request.method.lower() == 'get':
+            serializer = UserNotificationPreferenceSerializer(pref, context={'request': request})
+            return Response(serializer.data)
+
+        # PATCH
+        serializer = UserNotificationPreferenceSerializer(
+            pref,
+            data=request.data,
+            partial=True,
+            context={'request': request},
+        )
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        serializer.save()
+        return Response(serializer.data)
+
+    @action(detail=False, methods=['patch'], url_path='preferences/update_type', url_name='preferences-update-type')
+    def update_type_preference(self, request):
+        """Update the frequency for a specific notification type for the current startup user."""
+        pref = self._get_or_create_user_pref(request)
+
+        notification_type_id = request.data.get('notification_type_id')
+        frequency = request.data.get('frequency')
+
+        if notification_type_id is None or frequency is None:
+            return Response(
+                {'error': 'notification_type_id and frequency are required'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            nt_id = int(notification_type_id)
+        except (TypeError, ValueError):
+            return Response(
+                {'error': 'notification_type_id must be an integer'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        serializer = UpdateTypePreferenceSerializer(
+            data={'notification_type_id': nt_id, 'frequency': frequency},
+            context={'pref': pref},
+        )
+        try:
+            if not serializer.is_valid():
+                return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        except Exception as exc:
+            message = str(getattr(exc, 'detail', exc))
+            if 'not found' in message.lower():
+                return Response({'error': 'Notification type preference not found'}, status=status.HTTP_404_NOT_FOUND)
+            raise
+
+        type_pref = serializer.save()
+        return Response(UserNotificationTypePreferenceSerializer(type_pref, context={'request': request}).data)
+

--- a/tests/startups/test_startup_preferences.py
+++ b/tests/startups/test_startup_preferences.py
@@ -1,0 +1,127 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase, APIClient
+from rest_framework.authtoken.models import Token
+
+from tests.elasticsearch.factories import StartupFactory, UserFactory
+from tests.communications.factories import NotificationTypeFactory
+from communications.models import UserNotificationPreference, NotificationType
+
+
+class StartupNotificationPreferencesAPITests(APITestCase):
+    """Integration tests for startup notification preferences API:
+    verifies retrieval, channel toggles, per-type frequency updates, and permissions.
+    """
+    def setUp(self):
+        """Prepare two active types, create a startup user, and authenticate the client."""
+        self.notification_type1 = NotificationTypeFactory()
+        self.notification_type2 = NotificationTypeFactory()
+
+        self.startup = StartupFactory()
+        self.user = self.startup.user
+        self.token = Token.objects.create(user=self.user)
+
+        self.client.force_authenticate(user=self.user, token=self.token)
+
+    def test_get_preferences_creates_defaults(self):
+        """GET initializes default channel flags and seeds per-type preferences."""
+        url = reverse('startup-preferences')
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn('enable_in_app', resp.data)
+        self.assertIn('enable_email', resp.data)
+        self.assertIn('enable_push', resp.data)
+        self.assertIn('type_preferences', resp.data)
+        pref = UserNotificationPreference.objects.get(user=self.user)
+        self.assertEqual(pref.type_preferences.count(), NotificationType.objects.filter(is_active=True).count())
+
+    def test_patch_channel_preferences(self):
+        """PATCH updates enable_in_app/email/push channel toggles."""
+        _ = self.client.get(reverse('startup-preferences'))
+
+        url = reverse('startup-preferences')
+        payload = {
+            'enable_in_app': True,
+            'enable_email': False,
+            'enable_push': True,
+        }
+        resp = self.client.patch(url, payload, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertTrue(resp.data['enable_in_app'])
+        self.assertFalse(resp.data['enable_email'])
+        self.assertTrue(resp.data['enable_push'])
+
+    def test_update_type_preference_valid(self):
+        """PATCH per-type preference sets a valid frequency value successfully."""
+        pref_resp = self.client.get(reverse('startup-preferences'))
+        self.assertEqual(pref_resp.status_code, status.HTTP_200_OK)
+
+        pref = UserNotificationPreference.objects.get(user=self.user)
+        type_pref = pref.type_preferences.first()
+
+        url = reverse('startup-preferences-update-type')
+        payload = {
+            'notification_type_id': type_pref.notification_type.id,
+            'frequency': 'daily_digest',
+        }
+        resp = self.client.patch(url, payload, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['frequency'], 'daily_digest')
+
+    def test_update_type_preference_invalid_frequency(self):
+        """Return 400 when frequency is invalid for a type preference update."""
+        _ = self.client.get(reverse('startup-preferences'))
+        pref = UserNotificationPreference.objects.get(user=self.user)
+        type_pref = pref.type_preferences.first()
+
+        url = reverse('startup-preferences-update-type')
+        resp = self.client.patch(
+            url,
+            {'notification_type_id': type_pref.notification_type.id, 'frequency': 'invalid_freq'},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('frequency', resp.data)
+
+    def test_update_type_preference_invalid_type_id_non_integer(self):
+        """Return 400 when notification_type_id is not an integer."""
+        _ = self.client.get(reverse('startup-preferences'))
+
+        url = reverse('startup-preferences-update-type')
+        resp = self.client.patch(
+            url,
+            {'notification_type_id': 'abc', 'frequency': 'immediate'},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(resp.data.get('error'), 'notification_type_id must be an integer')
+
+    def test_update_type_preference_not_found(self):
+        """Return 404 when the user's seeded preferences do not include the requested type."""
+        _ = self.client.get(reverse('startup-preferences'))
+
+        another_type = NotificationTypeFactory()
+
+        url = reverse('startup-preferences-update-type')
+        resp = self.client.patch(
+            url,
+            {'notification_type_id': another_type.id, 'frequency': 'immediate'},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(resp.data.get('error'), 'Notification type preference not found')
+
+    def test_permission_denied_for_non_startup_user(self):
+        """Non-startup authenticated users are forbidden from accessing preference endpoints."""
+        other_user = UserFactory()
+        other_token = Token.objects.create(user=other_user)
+        client = APIClient()
+        client.force_authenticate(user=other_user, token=other_token)
+
+        list_url = reverse('startup-preferences')
+        resp = client.get(list_url)
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+        update_url = reverse('startup-preferences-update-type')
+        resp = client.patch(update_url, {}, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)

--- a/users/permissions.py
+++ b/users/permissions.py
@@ -37,9 +37,12 @@ class IsStartupUser(permissions.BasePermission):
             logger.warning(f"Permission denied: Unauthenticated user tried to access {view.__class__.__name__}.")
             return False
 
-        startup_id = getattr(user, 'startup_id', None)
-        if startup_id and Startup.objects.filter(id=startup_id).exists():
-            logger.debug(f"Permission granted: User {user.id} linked to startup {startup_id}.")
+        if hasattr(user, 'startup'):
+            logger.debug(f"Permission granted: User {user.id} linked to startup {getattr(user.startup, 'id', None)}.")
+            return True
+
+        if Startup.objects.filter(user_id=getattr(user, 'id', None)).exists():
+            logger.debug(f"Permission granted: User {user.id} linked to a startup via DB check.")
             return True
 
         logger.warning(f"Permission denied: User {user.id} has no valid startup linked.")


### PR DESCRIPTION
In this task, I implemented and validated startup notification preference management, including seeding defaults, channel toggles, and per-type frequency updates.

Tests cover defaults seeding, channel toggles, per-type updates, invalid inputs, and permissions. All tests passed successfully:
![Image 25 08 2025 at 4 28 PM](https://github.com/user-attachments/assets/423eb0c2-d866-4024-866a-182a8970b0d2)
