### PR TITLE
Issue 39 API Endpoints for Managing Email Notification Preferences

### DIFF
--- a/common/enums.py
+++ b/common/enums.py
@@ -40,3 +40,14 @@ class ProjectStatus(TextChoices):
     IN_PROGRESS = 'in_progress', 'In Progress'
     COMPLETED = 'completed', 'Completed'
     CANCELLED = 'cancelled', 'Cancelled'
+
+
+class NotificationTypeCode(TextChoices):
+    """
+    Canonical codes for NotificationType.code.
+    Keep this list in sync with the seeding command.
+    """
+    STARTUP_SAVED = 'startup_saved', 'Startup Saved'
+    PROJECT_FOLLOWED = 'project_followed', 'Project Followed'
+    MESSAGE_RECEIVED = 'message_received', 'Message Received'
+    ACTIVITY_SUMMARIZED = 'activity_summarized', 'Activity Summarized'

--- a/communications/management/__init__.py
+++ b/communications/management/__init__.py
@@ -1,0 +1,1 @@
+# Package initializer for communications.management

--- a/communications/management/commands/__init__.py
+++ b/communications/management/commands/__init__.py
@@ -1,0 +1,1 @@
+# Package initializer for communications.management.commands

--- a/communications/management/commands/seed_notification_types.py
+++ b/communications/management/commands/seed_notification_types.py
@@ -1,0 +1,98 @@
+from django.core.management.base import BaseCommand
+
+from communications.models import NotificationType, NotificationFrequency
+from common.enums import NotificationTypeCode
+
+
+class Command(BaseCommand):
+    help = "Seed canonical NotificationType rows (idempotent upsert)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would change without writing to the database.",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options.get("dry_run", False)
+
+        # Define canonical notification types here.
+        # Keep this in sync with common.enums.NotificationTypeCode
+        canonical_types = [
+            {
+                "code": NotificationTypeCode.STARTUP_SAVED.value,
+                "name": NotificationTypeCode.STARTUP_SAVED.label,
+                "description": "An investor saved your startup profile.",
+                "default_frequency": NotificationFrequency.IMMEDIATE,
+            },
+            {
+                "code": NotificationTypeCode.PROJECT_FOLLOWED.value,
+                "name": NotificationTypeCode.PROJECT_FOLLOWED.label,
+                "description": "An investor followed your project.",
+                "default_frequency": NotificationFrequency.IMMEDIATE,
+            },
+            {
+                "code": NotificationTypeCode.MESSAGE_RECEIVED.value,
+                "name": NotificationTypeCode.MESSAGE_RECEIVED.label,
+                "description": "You received a new message.",
+                "default_frequency": NotificationFrequency.IMMEDIATE,
+            },
+            {
+                "code": NotificationTypeCode.ACTIVITY_SUMMARIZED.value,
+                "name": NotificationTypeCode.ACTIVITY_SUMMARIZED.label,
+                "description": "Your weekly activity summary is ready.",
+                "default_frequency": NotificationFrequency.WEEKLY_SUMMARY,
+            },
+        ]
+
+        created_count = 0
+        updated_count = 0
+
+        for item in canonical_types:
+            code = item["code"]
+            name = item["name"]
+            description = item["description"]
+            default_frequency = item["default_frequency"]
+
+            existing = NotificationType.objects.filter(code=code).first()
+            if not existing:
+                if dry_run:
+                    self.stdout.write(self.style.WARNING(f"(dry-run) Would create NotificationType: {code}"))
+                else:
+                    NotificationType.objects.create(
+                        code=code,
+                        name=name,
+                        description=description,
+                        default_frequency=default_frequency,
+                    )
+                    created_count += 1
+                    self.stdout.write(self.style.SUCCESS(f"Created NotificationType: {code}"))
+                continue
+
+            # Upsert fields if changed (do not touch is_active to respect admin choice)
+            changed_fields = {}
+            if existing.name != name:
+                changed_fields["name"] = name
+            if (existing.description or "") != (description or ""):
+                changed_fields["description"] = description
+            if existing.default_frequency != default_frequency:
+                changed_fields["default_frequency"] = default_frequency
+
+            if changed_fields:
+                updated_count += 1
+                if dry_run:
+                    self.stdout.write(self.style.WARNING(f"(dry-run) Would update {code}: {', '.join(changed_fields.keys())}"))
+                else:
+                    for field, value in changed_fields.items():
+                        setattr(existing, field, value)
+                    existing.save(update_fields=[*changed_fields.keys(), "updated_at"])
+                    self.stdout.write(self.style.SUCCESS(f"Updated NotificationType: {code}"))
+            else:
+                self.stdout.write(f"No changes for NotificationType: {code}")
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Done. Created: {created_count}, Updated: {updated_count}."
+            )
+        )

--- a/communications/services.py
+++ b/communications/services.py
@@ -138,3 +138,103 @@ def create_in_app_notification(
         triggered_by_user=triggered_by_user,
         triggered_by_type=triggered_by_type,
     )
+
+
+def create_email_notification(
+    *,
+    user: User,
+    type_code: str,
+    subject: str,
+    message: str,
+    template_name: str = None,
+    context: dict = None,
+    priority: Optional[str] = None,
+    related_startup_id: Optional[int] = None,
+    related_project_id: Optional[int] = None,
+    related_message_id: Optional[int] = None,
+    triggered_by_user: Optional[User] = None,
+    triggered_by_type: Optional[str] = None,
+) -> bool:
+    """
+    Send an email notification only if user's preferences allow it.
+    Returns True if email was sent, False if suppressed by preferences.
+    
+    Args:
+        user: The recipient user
+        type_code: Notification type code
+        subject: Email subject line
+        message: Plain text email message content
+        template_name: Optional template for HTML email
+        context: Optional context dict for template rendering
+        priority: Optional priority level
+        related_startup_id: Optional related startup ID
+        related_project_id: Optional related project ID
+        related_message_id: Optional related message ID
+        triggered_by_user: Optional user who triggered this notification
+        triggered_by_type: Optional type of trigger (investor/startup/system)
+    """
+    try:
+        ntype = NotificationType.objects.get(code=type_code)
+    except NotificationType.DoesNotExist:
+        logger.warning("Unknown notification type code: %s", type_code)
+        return False
+
+    if not is_channel_enabled(user, "email"):
+        logger.info("Suppressing email notification for user=%s (email channel disabled)",
+                   getattr(user, "id", None))
+        return False
+    if not is_type_allowed(user, ntype):
+        logger.info(
+            "Suppressing email notification for user=%s type=%s (type disabled)",
+            getattr(user, "id", None), ntype.code,
+        )
+        return False
+
+    user_pref = _get_user_pref(user)
+    if user_pref:
+        type_pref = _get_type_pref(user_pref, ntype)
+        if type_pref and type_pref.frequency != "immediate":
+            logger.info(
+                "Queueing email for digest/summary for user=%s type=%s frequency=%s",
+                getattr(user, "id", None), ntype.code, type_pref.frequency
+            )
+            return True
+
+    try:
+        from django.core.mail import send_mail
+        from django.template.loader import render_to_string
+        from django.utils.html import strip_tags
+        
+        email_context = context or {}
+        email_context.update({
+            'subject': subject,
+            'message': message,
+            'notification_type': ntype,
+            'user': user,
+            'priority': priority,
+        })
+        
+        if template_name:
+            html_message = render_to_string(template_name, email_context)
+            plain_message = strip_tags(html_message)
+        else:
+            html_message = f"<html><body><h2>{subject}</h2><p>{message}</p></body></html>"
+            plain_message = message
+            
+        send_mail(
+            subject=subject,
+            message=plain_message,
+            from_email=None,
+            recipient_list=[user.email],
+            html_message=html_message,
+            fail_silently=False,
+        )
+        
+        logger.info(
+            "Email notification sent to user=%s type=%s",
+            getattr(user, "id", None), ntype.code
+        )
+        return True
+    except Exception as e:
+        logger.exception("Failed to send email notification: %s", str(e))
+        return False

--- a/communications/urls.py
+++ b/communications/urls.py
@@ -31,3 +31,13 @@ app_name = 'communications'
 urlpatterns = [
     path('', include(router.urls)),
 ]
+
+urlpatterns += [
+    path('preferences/email-preferences/', 
+         UserNotificationPreferenceViewSet.as_view({'get': 'get_email_preferences'}), 
+         name='user-notification-preference-email-preferences'),
+         
+    path('preferences/<int:pk>/email-preferences/', 
+         UserNotificationPreferenceViewSet.as_view({'patch': 'update_email_preferences'}), 
+         name='user-notification-preference-update-email-preferences'),
+]

--- a/communications/views.py
+++ b/communications/views.py
@@ -29,6 +29,20 @@ class DefaultPageNumberPagination(PageNumberPagination):
 logger = logging.getLogger(__name__)
 
 
+def _parse_bool(val):
+    """Parse a value into a boolean, accepting various string representations."""
+    if isinstance(val, bool):
+        return val
+    if val is None:
+        return None
+    s = str(val).strip().lower()
+    if s in {'1', 'true', 'yes'}:
+        return True
+    if s in {'0', 'false', 'no'}:
+        return False
+    return None
+
+
 class NotificationViewSet(
     mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
@@ -61,18 +75,6 @@ class NotificationViewSet(
         )
 
         params = self.request.query_params
-
-        def _parse_bool(val):
-            if isinstance(val, bool):
-                return val
-            if val is None:
-                return None
-            s = str(val).strip().lower()
-            if s in {'1', 'true', 'yes'}:
-                return True
-            if s in {'0', 'false', 'no'}:
-                return False
-            return None
 
         is_read_param = _parse_bool(params.get('is_read'))
         if is_read_param is not None:
@@ -289,6 +291,167 @@ class UserNotificationPreferenceViewSet(viewsets.ModelViewSet):
             serializer.instance.frequency,
         )
         return Response(serializer.data)
+
+    @action(detail=True, methods=['patch'], url_path='email-preferences')
+    def update_email_preferences(self, request, pk=None):
+        """
+        Update email notification preferences.
+        
+        This endpoint allows startups to opt-in or opt-out of receiving email notifications.
+        
+        Parameters:
+        - enable_email: Boolean to globally enable/disable all email notifications
+        - type_preferences: Optional list of notification type preferences with format:
+          [{"notification_type_id": 1, "frequency": "immediate|daily_digest|weekly_summary|disabled"}]
+          
+        Returns the updated notification preferences.
+        """
+        preference = self.get_object()
+        enable_email = request.data.get('enable_email')
+        if enable_email is not None:
+            parsed_value = _parse_bool(enable_email)
+            if parsed_value is None:
+                return Response(
+                    {'error': 'enable_email must be a boolean value'},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+            
+            preference.enable_email = parsed_value
+            preference.save(update_fields=['enable_email', 'updated_at'])
+            logger.info(
+                "notifications.update_email_preferences user=%s enable_email=%s",
+                getattr(request.user, 'user_id', getattr(request.user, 'id', None)),
+                parsed_value,
+            )
+        
+        type_preferences = request.data.get('type_preferences', [])
+        if type_preferences and not isinstance(type_preferences, list):
+            return Response(
+                {'error': 'type_preferences must be a list'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+            
+        updated_types = []
+        errors = []
+        
+        for i, type_pref_data in enumerate(type_preferences):
+            if not isinstance(type_pref_data, dict):
+                errors.append({
+                    'index': i,
+                    'error': 'Each type preference must be an object'
+                })
+                continue
+                
+            notification_type_id = type_pref_data.get('notification_type_id')
+            frequency = type_pref_data.get('frequency')
+            
+            if not notification_type_id:
+                errors.append({
+                    'index': i,
+                    'error': 'notification_type_id is required'
+                })
+                continue
+                
+            if not frequency:
+                errors.append({
+                    'index': i,
+                    'error': 'frequency is required'
+                })
+                continue
+                
+            try:
+                nt_id = int(notification_type_id)
+            except (TypeError, ValueError):
+                errors.append({
+                    'index': i,
+                    'error': 'notification_type_id must be an integer'
+                })
+                continue
+                
+            type_pref = preference.type_preferences.filter(notification_type_id=nt_id).first()
+            if not type_pref:
+                errors.append({
+                    'index': i,
+                    'error': f'Notification type preference with id {nt_id} not found'
+                })
+                continue
+                
+            old_frequency = type_pref.frequency
+            serializer = UserNotificationTypePreferenceSerializer(
+                type_pref,
+                data={'frequency': frequency},
+                partial=True,
+                context={'request': request},
+            )
+            if not serializer.is_valid():
+                errors.append({
+                    'index': i,
+                    'error': serializer.errors
+                })
+                continue
+                
+            serializer.save()
+            updated_types.append(nt_id)
+            logger.info(
+                "notifications.update_email_type_preference user=%s notification_type_id=%s %s->%s",
+                getattr(request.user, 'user_id', getattr(request.user, 'id', None)),
+                nt_id,
+                old_frequency,
+                serializer.instance.frequency,
+            )
+        response_data = self.get_serializer(preference).data
+        if errors:
+            response_data['errors'] = errors
+        if updated_types:
+            response_data['updated_types'] = updated_types
+            
+        if errors:
+            if len(errors) == 1:
+                response_data['error'] = errors[0]['error']
+            return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
+            
+        return Response(response_data)
+
+    @action(detail=False, methods=['get'], url_path='email-preferences')
+    def get_email_preferences(self, request):
+        """
+        Get the current user's email notification preferences.
+        
+        This endpoint returns a dedicated view of the user's notification preferences
+        specific to email notifications, formatted to make it easy for startups
+        to manage their email notification settings.
+        
+        Returns:
+        - enable_email: Boolean indicating if email notifications are globally enabled
+        - notification_types: List of notification types with their current preferences
+          [
+            {
+              "id": 1,
+              "code": "new_follower",
+              "name": "New Follower",
+              "description": "When someone follows your startup",
+              "frequency": "immediate",
+              "is_active": true
+            }
+          ]
+        """
+        preference = self.get_object()
+        notification_types = []
+        for type_pref in preference.type_preferences.select_related('notification_type').all():
+            nt = type_pref.notification_type
+            notification_types.append({
+                'id': nt.id,
+                'code': nt.code,
+                'name': nt.name,
+                'description': nt.description,
+                'frequency': type_pref.frequency,
+                'is_active': nt.is_active
+            })
+            
+        return Response({
+            'enable_email': preference.enable_email,
+            'notification_types': notification_types
+        })
 
     @action(detail=False, methods=['get'], url_path='options', url_name='preference-options')
     def preference_options(self, request):

--- a/core/settings/constants.py
+++ b/core/settings/constants.py
@@ -61,10 +61,10 @@ COMMUNICATIONS_NOTIFICATION_TYPES = [
         'is_active': True,
     },
     {
-        'code': 'project_updated',
-        'name': 'Project Updated',
-        'description': 'Notification when a followed project is updated',
-        'default_frequency': 'daily_digest',
+        'code': 'activity_summarized',
+        'name': 'Activity Summarized',
+        'description': 'Weekly summary of your activity',
+        'default_frequency': 'weekly_summary',
         'is_active': True,
     },
 ]

--- a/core/urls.py
+++ b/core/urls.py
@@ -18,7 +18,7 @@ urlpatterns = [
     # Versioned API
     path('api/v1/auth/', include('users.urls')),
     path('api/v1/projects/', include('projects.urls')),
-    path('api/v1/startups/', include('startups.urls')),
+    path('api/v1/startups/', include(('startups.urls', 'startups'), namespace='startups')),
     path('api/v1/investors/', include('investors.urls')),
     path('api/v1/investments/', include(('investments.urls', 'investments'), namespace='investments')),
     path('api/v1/communications/', include('communications.urls')),

--- a/docs/API.md
+++ b/docs/API.md
@@ -142,6 +142,120 @@ sequenceDiagram
 - `PATCH /api/profiles/startups/{id}/` — Update an existing startup profile
 - `DELETE /api/profiles/startups/{id}/` — Delete a startup profile
 
+### Startup Notification Preferences
+
+All endpoints require authentication and the Startup role. Base path: `/api/v1/startups/`.
+
+- `GET /api/v1/startups/preferences/` — Get the current startup user's notification channel preferences. If preferences do not exist, defaults are created and per-type preferences are seeded for all active notification types.
+- `PATCH /api/v1/startups/preferences/` — Update channel toggles (`enable_in_app`, `enable_email`, `enable_push`). Partial updates supported.
+- `PATCH /api/v1/startups/preferences/update_type/` — Update the frequency for a specific notification type. Payload requires `notification_type_id` (int) and `frequency` (one of `immediate`, `daily_digest`, `weekly_summary`, `disabled`).
+
+#### Example: GET /api/v1/startups/preferences/
+
+Response 200
+
+```json
+{
+  "user_id": 12,
+  "enable_in_app": true,
+  "enable_email": true,
+  "enable_push": true,
+  "type_preferences": [
+    {
+      "id": 101,
+      "notification_type": { "id": 3, "code": "message_received", "name": "Message Received", "description": "A new message was received", "is_active": true },
+      "frequency": "immediate",
+      "created_at": "2025-08-05T12:00:00Z",
+      "updated_at": "2025-08-05T12:00:00Z"
+    }
+  ],
+  "created_at": "2025-08-05T12:00:00Z",
+  "updated_at": "2025-08-05T12:00:00Z"
+}
+```
+
+#### Example: PATCH /api/v1/startups/preferences/
+
+Request
+
+```json
+{
+  "enable_in_app": true,
+  "enable_email": false,
+  "enable_push": true
+}
+```
+
+Response 200
+
+```json
+{
+  "user_id": 12,
+  "enable_in_app": true,
+  "enable_email": false,
+  "enable_push": true,
+  "type_preferences": [ /* ... */ ]
+}
+```
+
+#### Example: PATCH /api/v1/startups/preferences/update_type/
+
+Request
+
+```json
+{
+  "notification_type_id": 3,
+  "frequency": "daily_digest"
+}
+```
+
+Response 200
+
+```json
+{
+  "id": 101,
+  "notification_type": { "id": 3, "code": "message_received", "name": "Message Received", "description": "A new message was received", "is_active": true },
+  "frequency": "daily_digest",
+  "created_at": "2025-08-05T12:00:00Z",
+  "updated_at": "2025-08-05T12:05:00Z"
+}
+```
+
+Error responses
+
+- 400 Missing fields
+
+```json
+{
+  "notification_type_id": ["This field is required."],
+  "frequency": ["This field is required."]
+}
+```
+
+- 400 Invalid notification_type_id (non-integer)
+
+```json
+{
+  "notification_type_id": ["A valid integer is required."]
+}
+```
+
+- 400 Invalid frequency value
+
+```json
+{
+  "frequency": ["\"invalid_freq\" is not a valid choice."]
+}
+```
+
+- 404 Notification type preference not found
+
+```json
+{
+  "error": "Notification type preference not found"
+}
+```
+
 ## Investor API
 
 ### Endpoints
@@ -390,8 +504,8 @@ Creation of notifications via public API is disabled.
       "notification_id": "b6b9e6f4-8f5a-4e58-9e7f-2d3b1f7ac111",
       "notification_type": {
         "id": 3,
-        "code": "message_new",
-        "name": "New Message",
+        "code": "message_received",
+        "name": "Message Received",
         "description": "A new message was received",
         "is_active": true
       },

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -678,13 +678,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedUserNotificationPreferenceRequest'
+              $ref: '#/components/schemas/UserNotificationTypePreferenceRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedUserNotificationPreferenceRequest'
+              $ref: '#/components/schemas/UserNotificationTypePreferenceRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedUserNotificationPreferenceRequest'
+              $ref: '#/components/schemas/UserNotificationTypePreferenceRequest'
       security:
       - bearerAuth: []
       responses:
@@ -692,7 +692,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserNotificationPreference'
+                $ref: '#/components/schemas/UserNotificationTypePreference'
           description: ''
   /api/v1/communications/preferences/{id}/update_type_preference/:
     patch:
@@ -2248,6 +2248,247 @@ paths:
               schema:
                 $ref: '#/components/schemas/StartupDocument'
           description: ''
+  /api/v1/startups/preferences/:
+    get:
+      operationId: startups_preferences_retrieve
+      description: Get current startup user's notification channel preferences.
+      tags:
+      - startups
+      security:
+      - bearerAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserNotificationPreference'
+              example:
+                user_id: 42
+                enable_in_app: true
+                enable_email: true
+                enable_push: false
+                type_preferences:
+                - id: 1
+                  notification_type:
+                    id: 3
+                    code: message_received
+                    name: Message Received
+                    description: New message received
+                    is_active: true
+                  frequency: immediate
+                  created_at: '2025-01-01T12:00:00Z'
+                  updated_at: '2025-01-01T12:00:00Z'
+                - id: 2
+                  notification_type:
+                    id: 4
+                    code: activity_summarized
+                    name: Activity Summarized
+                    description: Weekly summary of activity
+                    is_active: true
+                  frequency: weekly_summary
+                  created_at: '2025-01-01T12:00:00Z'
+                  updated_at: '2025-01-01T12:00:00Z'
+          description: ''
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                required:
+                - detail
+              example:
+                detail: Authentication credentials were not provided.
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                required:
+                - detail
+              example:
+                detail: You do not have permission to perform this action.
+    patch:
+      operationId: startups_preferences_partial_update
+      description: Update current startup user's notification channel preferences.
+      tags:
+      - startups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedUserNotificationPreferenceRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedUserNotificationPreferenceRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedUserNotificationPreferenceRequest'
+        required: true
+      security:
+      - bearerAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserNotificationPreference'
+              example:
+                user_id: 42
+                enable_in_app: true
+                enable_email: false
+                enable_push: false
+                type_preferences:
+                - id: 1
+                  notification_type:
+                    id: 3
+                    code: message_received
+                    name: Message Received
+                    description: New message received
+                    is_active: true
+                  frequency: immediate
+                  created_at: '2025-01-01T12:00:00Z'
+                  updated_at: '2025-01-08T12:00:00Z'
+          description: ''
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: array
+                  items:
+                    type: string
+              example:
+                enable_email:
+                - Must be a valid boolean.
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                required:
+                - detail
+              example:
+                detail: Authentication credentials were not provided.
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                required:
+                - detail
+              example:
+                detail: You do not have permission to perform this action.
+  /api/v1/startups/preferences/update_type/:
+    patch:
+      operationId: startups_preferences_update_type_partial_update
+      description: |-
+        Update the frequency for a specific notification type for the current startup user.
+        Expected payload: {"notification_type_id": 1, "frequency": "immediate"}
+        Errors: 400 (validation), 404 (preference not found)
+      tags:
+      - startups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserNotificationTypePreferenceRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/UserNotificationTypePreferenceRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/UserNotificationTypePreferenceRequest'
+        required: true
+      security:
+      - bearerAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserNotificationTypePreference'
+              example:
+                id: 10
+                notification_type:
+                  id: 4
+                  code: activity_summarized
+                  name: Activity Summarized
+                  description: Weekly summary of activity
+                  is_active: true
+                frequency: weekly_summary
+                created_at: '2025-01-01T12:00:00Z'
+                updated_at: '2025-01-08T12:00:00Z'
+          description: ''
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: array
+                  items:
+                    type: string
+              example:
+                frequency:
+                - "'monthly' is not a valid choice."
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                required:
+                - detail
+              example:
+                detail: Authentication credentials were not provided.
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                required:
+                - detail
+              example:
+                detail: You do not have permission to perform this action.
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                required:
+                - detail
+              example:
+                detail: Preference not found.
 components:
   schemas:
     Category:

--- a/startups/urls.py
+++ b/startups/urls.py
@@ -20,6 +20,10 @@ startup_preferences_update = StartupViewSet.as_view({
     'patch': 'preferences',
 })
 
+startup_update_type_preference = StartupViewSet.as_view({
+    'patch': 'update_type_preference',
+})
+
 startup_email_preferences_get = StartupViewSet.as_view({
     'get': 'get_email_preferences',
 })
@@ -32,6 +36,7 @@ startup_email_preferences_update = StartupViewSet.as_view({
 urlpatterns += [
     path('preferences/', startup_viewset, name='preferences'),
     path('preferences/update/', startup_preferences_update, name='preferences-update'),
+    path('preferences/update-type/', startup_update_type_preference, name='preferences-update-type'),
     path('preferences/email/', startup_email_preferences_get, name='email-preferences-get'),
     path('preferences/email/update/', startup_email_preferences_update, name='email-preferences-update'),
 ]

--- a/startups/urls.py
+++ b/startups/urls.py
@@ -1,10 +1,37 @@
 from rest_framework.routers import DefaultRouter
+from django.urls import path
 
 from startups.views.startup import StartupViewSet
 from startups.views.startup_elasticsearch import StartupDocumentView
 
 router = DefaultRouter()
-router.register(r'', StartupViewSet, basename='startup')
+router.register(r'', StartupViewSet, basename='startups')
 router.register(r'search', StartupDocumentView, basename='startups-search')
 
+# Get the router's URL patterns
 urlpatterns = router.urls
+
+# Add explicit URL patterns for the notification preferences endpoints
+startup_viewset = StartupViewSet.as_view({
+    'get': 'preferences',
+})
+
+startup_preferences_update = StartupViewSet.as_view({
+    'patch': 'preferences',
+})
+
+startup_email_preferences_get = StartupViewSet.as_view({
+    'get': 'get_email_preferences',
+})
+
+startup_email_preferences_update = StartupViewSet.as_view({
+    'patch': 'update_email_preferences',
+})
+
+# Add these URL patterns to the urlpatterns list
+urlpatterns += [
+    path('preferences/', startup_viewset, name='preferences'),
+    path('preferences/update/', startup_preferences_update, name='preferences-update'),
+    path('preferences/email/', startup_email_preferences_get, name='email-preferences-get'),
+    path('preferences/email/update/', startup_email_preferences_update, name='email-preferences-update'),
+]

--- a/startups/views/startup.py
+++ b/startups/views/startup.py
@@ -44,7 +44,6 @@ class StartupViewSet(BaseValidatedModelViewSet):
             serializer = UserNotificationPreferenceSerializer(pref, context={'request': request})
             return Response(serializer.data)
 
-        # PATCH
         serializer = UserNotificationPreferenceSerializer(
             pref,
             data=request.data,

--- a/startups/views/startup.py
+++ b/startups/views/startup.py
@@ -16,6 +16,7 @@ from communications.serializers import (
     UpdateTypePreferenceSerializer,
 )
 from communications.services import get_or_create_user_pref
+from communications.views import _parse_bool
 
 class StartupViewSet(BaseValidatedModelViewSet):
     queryset = Startup.objects.select_related('user', 'industry', 'location') \
@@ -27,78 +28,6 @@ class StartupViewSet(BaseValidatedModelViewSet):
     filter_backends = [DjangoFilterBackend, SearchFilter]
     filterset_fields = ['industry', 'stage', 'location__country']
     search_fields = ['company_name', 'user__first_name', 'user__last_name', 'email']
-
-    def _get_or_create_user_pref(self, request):
-        """Fetch the current user's notification preferences, creating defaults if absent.
-        Delegates to communications.services.get_or_create_user_pref to avoid duplication and
-        to seed type preferences using each NotificationType.default_frequency.
-        """
-        return get_or_create_user_pref(request.user)
-
-    @action(detail=False, methods=['get', 'patch'], url_path='preferences', url_name='preferences')
-    def preferences(self, request):
-        """Get or update the current startup user's notification channel preferences."""
-        pref = self._get_or_create_user_pref(request)
-
-        if request.method.lower() == 'get':
-            serializer = UserNotificationPreferenceSerializer(pref, context={'request': request})
-            return Response(serializer.data)
-
-        serializer = UserNotificationPreferenceSerializer(
-            pref,
-            data=request.data,
-            partial=True,
-            context={'request': request},
-        )
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-        serializer.save()
-        return Response(serializer.data)
-
-    @action(detail=False, methods=['patch'], url_path='preferences/update_type', url_name='preferences-update-type')
-    def update_type_preference(self, request):
-        """Update the frequency for a specific notification type for the current startup user."""
-        pref = self._get_or_create_user_pref(request)
-
-        notification_type_id = request.data.get('notification_type_id')
-        frequency = request.data.get('frequency')
-
-        if notification_type_id is None or frequency is None:
-            errors = {}
-            if notification_type_id is None:
-                errors['notification_type_id'] = ['This field is required.']
-            if frequency is None:
-                errors['frequency'] = ['This field is required.']
-            return Response(errors, status=status.HTTP_400_BAD_REQUEST)
-
-        try:
-            nt_id = int(notification_type_id)
-        except (TypeError, ValueError):
-            return Response({'notification_type_id': ['A valid integer is required.']}, status=status.HTTP_400_BAD_REQUEST)
-
-        serializer = UpdateTypePreferenceSerializer(
-            data={'notification_type_id': nt_id, 'frequency': frequency},
-            context={'pref': pref},
-        )
-        try:
-            if not serializer.is_valid():
-                errors = serializer.errors
-                non_field = errors.get('non_field_errors') if isinstance(errors, dict) else None
-                if non_field:
-                    for err in non_field:
-                        code = getattr(err, 'code', None)
-                        if code == 'not_found' or str(err) == 'Notification type preference not found':
-                            return Response({'error': 'Notification type preference not found'}, status=status.HTTP_404_NOT_FOUND)
-                return Response(errors, status=status.HTTP_400_BAD_REQUEST)
-        except NotFound:
-            return Response({'error': 'Notification type preference not found'}, status=status.HTTP_404_NOT_FOUND)
-        except ValidationError as exc:
-            detail = getattr(exc, 'detail', None)
-            return Response(detail or serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-        type_pref = serializer.save()
-        return Response(UserNotificationTypePreferenceSerializer(type_pref, context={'request': request}).data)
-
 
     def _get_or_create_user_pref(self, request):
         """Fetch the current user's notification preferences, creating defaults if absent.
@@ -172,6 +101,155 @@ class StartupViewSet(BaseValidatedModelViewSet):
         type_pref = serializer.save()
         return Response(UserNotificationTypePreferenceSerializer(type_pref, context={'request': request}).data)
 
+    @action(detail=False, methods=['get'], url_path='preferences/email-preferences', url_name='email-preferences-get')
+    def get_email_preferences(self, request):
+        """
+        Get the current startup user's email notification preferences.
+        
+        This endpoint returns a dedicated view of the user's notification preferences
+        specific to email notifications, formatted to make it easy for startups
+        to manage their email notification settings.
+        
+        Returns:
+        - enable_email: Boolean indicating if email notifications are globally enabled
+        - notification_types: List of notification types with their current preferences
+          [
+            {
+              "id": 1,
+              "code": "new_follower",
+              "name": "New Follower",
+              "description": "When someone follows your startup",
+              "frequency": "immediate",
+              "is_active": true
+            }
+          ]
+        """
+        preference = self._get_or_create_user_pref(request)
+        notification_types = []
+        for type_pref in preference.type_preferences.select_related('notification_type').all():
+            nt = type_pref.notification_type
+            notification_types.append({
+                'id': nt.id,
+                'code': nt.code,
+                'name': nt.name,
+                'description': nt.description,
+                'frequency': type_pref.frequency,
+                'is_active': nt.is_active
+            })
+            
+        return Response({
+            'enable_email': preference.enable_email,
+            'notification_types': notification_types
+        })
+
+    @action(detail=False, methods=['patch'], url_path='preferences/email-preferences', url_name='email-preferences-update')
+    def update_email_preferences(self, request):
+        """
+        Update email notification preferences for the current startup user.
+        
+        This endpoint allows startups to opt-in or opt-out of receiving email notifications.
+        
+        Parameters:
+        - enable_email: Boolean to globally enable/disable all email notifications
+        - type_preferences: Optional list of notification type preferences with format:
+          [{"notification_type_id": 1, "frequency": "immediate|daily_digest|weekly_summary|disabled"}]
+          
+        Returns the updated notification preferences.
+        """
+        preference = self._get_or_create_user_pref(request)
+        enable_email = request.data.get('enable_email')
+        if enable_email is not None:
+            parsed_value = _parse_bool(enable_email)
+            if parsed_value is None:
+                return Response(
+                    {'error': 'enable_email must be a boolean value'},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+            
+            preference.enable_email = parsed_value
+            preference.save(update_fields=['enable_email', 'updated_at'])
+        
+        type_preferences = request.data.get('type_preferences', [])
+        if type_preferences and not isinstance(type_preferences, list):
+            return Response(
+                {'error': 'type_preferences must be a list'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+            
+        updated_types = []
+        errors = []
+        
+        for i, type_pref_data in enumerate(type_preferences):
+            if not isinstance(type_pref_data, dict):
+                errors.append({
+                    'index': i,
+                    'error': 'Each type preference must be an object'
+                })
+                continue
+                
+            notification_type_id = type_pref_data.get('notification_type_id')
+            frequency = type_pref_data.get('frequency')
+            
+            if not notification_type_id:
+                errors.append({
+                    'index': i,
+                    'error': 'notification_type_id is required'
+                })
+                continue
+                
+            if not frequency:
+                errors.append({
+                    'index': i,
+                    'error': 'frequency is required'
+                })
+                continue
+                
+            try:
+                nt_id = int(notification_type_id)
+            except (TypeError, ValueError):
+                errors.append({
+                    'index': i,
+                    'error': 'notification_type_id must be an integer'
+                })
+                continue
+                
+            type_pref = preference.type_preferences.filter(notification_type_id=nt_id).first()
+            if not type_pref:
+                errors.append({
+                    'index': i,
+                    'error': f'Notification type preference with id {nt_id} not found'
+                })
+                continue
+                
+            old_frequency = type_pref.frequency
+            serializer = UserNotificationTypePreferenceSerializer(
+                type_pref,
+                data={'frequency': frequency},
+                partial=True,
+                context={'request': request},
+            )
+            if not serializer.is_valid():
+                errors.append({
+                    'index': i,
+                    'error': serializer.errors
+                })
+                continue
+                
+            serializer.save()
+            updated_types.append(nt_id)
+            
+        response_data = UserNotificationPreferenceSerializer(preference, context={'request': request}).data
+        if updated_types:
+            response_data['updated_types'] = updated_types
+            
+        if errors:
+            response_data['errors'] = errors
+            response_data['error'] = 'One or more type preferences have invalid values'
+            if len(errors) == len(type_preferences):
+                # All updates failed
+                return Response(response_data, status=status.HTTP_400_BAD_REQUEST)
+            
+        return Response(response_data)
 
     def get_permissions(self):
         """
@@ -188,4 +266,3 @@ class StartupViewSet(BaseValidatedModelViewSet):
         if self.action == 'create':
             return StartupCreateSerializer
         return StartupSerializer
-        

--- a/tests/communications/test_startup_notification_preferences.py
+++ b/tests/communications/test_startup_notification_preferences.py
@@ -1,0 +1,254 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+from django.contrib.auth import get_user_model
+from rest_framework.authtoken.models import Token
+from communications.models import NotificationType, UserNotificationPreference
+import ddt
+from tests.factories import UserFactory
+from tests.communications.factories import NotificationTypeFactory
+from rest_framework.test import APIClient
+import logging
+from startups.models import Startup, Industry, Location
+from common.enums import Stage
+
+User = get_user_model()
+
+
+@ddt.ddt
+class StartupNotificationPreferencesTestCase(APITestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Silence logs produced by this test class only
+        logging.disable(logging.CRITICAL)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Re-enable logging for the rest of the test suite
+        logging.disable(logging.NOTSET)
+        super().tearDownClass()
+        
+    def setUp(self):
+        """Common setup using factories for user and notification types."""
+        self.notification_type1 = NotificationTypeFactory(default_frequency='immediate')
+        self.notification_type2 = NotificationTypeFactory(default_frequency='daily_digest')
+
+        # Create a regular user
+        self.startup_user = UserFactory()
+        self.token = Token.objects.create(user=self.startup_user)
+        
+        # Create a startup associated with this user
+        self.industry = Industry.objects.create(name="Test Industry")
+        self.location = Location.objects.create(country="US", city="Test City")
+        self.startup = Startup.objects.create(
+            user=self.startup_user,
+            company_name="Test Startup",
+            description="A startup for testing",
+            industry=self.industry,
+            location=self.location,
+            email="test@example.com",
+            founded_year=2020,
+            team_size=5,
+            stage=Stage.MVP
+        )
+        
+        self.client.force_authenticate(user=self.startup_user, token=self.token)
+
+    def test_get_startup_preferences(self):
+        """Test retrieving startup notification preferences."""
+        url = reverse('startups:preferences')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('user_id', response.data)
+        self.assertEqual(response.data['user_id'], self.startup_user.pk)
+        self.assertIn('enable_in_app', response.data)
+        self.assertIn('enable_email', response.data)
+        self.assertIn('enable_push', response.data)
+        self.assertIn('type_preferences', response.data)
+        self.assertIsInstance(response.data['type_preferences'], list)
+
+    def test_update_startup_preferences(self):
+        """Test updating startup notification preferences."""
+        url = reverse('startups:preferences-update')
+        
+        data = {
+            'enable_in_app': True,
+            'enable_email': False,
+            'enable_push': True
+        }
+        response = self.client.patch(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data['enable_in_app'])
+        self.assertFalse(response.data['enable_email'])
+        self.assertTrue(response.data['enable_push'])
+
+        pref = UserNotificationPreference.objects.get(user=self.startup_user)
+        self.assertTrue(pref.enable_in_app)
+        self.assertFalse(pref.enable_email)
+        self.assertTrue(pref.enable_push)
+
+    def test_get_startup_email_preferences(self):
+        """Test retrieving startup email notification preferences."""
+        url = reverse('startups:email-preferences-get')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('enable_email', response.data)
+        self.assertIn('notification_types', response.data)
+        self.assertIsInstance(response.data['notification_types'], list)
+
+        if len(response.data['notification_types']) > 0:
+            type_data = response.data['notification_types'][0]
+            self.assertIn('id', type_data)
+            self.assertIn('code', type_data)
+            self.assertIn('name', type_data)
+            self.assertIn('frequency', type_data)
+            self.assertIn('is_active', type_data)
+
+    def test_update_startup_email_preferences(self):
+        """Test updating startup email notification preferences."""
+        url = reverse('startups:email-preferences-update')
+        
+        notification_types = list(NotificationType.objects.all()[:2])
+        
+        data = {
+            'enable_email': True,
+            'type_preferences': [
+                {
+                    'notification_type_id': notification_types[0].id,
+                    'frequency': 'immediate'
+                },
+                {
+                    'notification_type_id': notification_types[1].id,
+                    'frequency': 'daily_digest'
+                }
+            ]
+        }
+        
+        response = self.client.patch(url, data, format='json')
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data['enable_email'])
+        
+        self.assertIn('type_preferences', response.data)
+        self.assertIn('updated_types', response.data)
+        self.assertEqual(len(response.data['updated_types']), 2)
+        self.assertIn(notification_types[0].id, response.data['updated_types'])
+        self.assertIn(notification_types[1].id, response.data['updated_types'])
+        
+        pref = UserNotificationPreference.objects.get(user=self.startup_user)
+        self.assertTrue(pref.enable_email)
+        
+        type_pref = pref.type_preferences.get(notification_type=notification_types[0])
+        self.assertEqual(type_pref.frequency, 'immediate')
+        
+        type_pref = pref.type_preferences.get(notification_type=notification_types[1])
+        self.assertEqual(type_pref.frequency, 'daily_digest')
+
+    def test_update_startup_email_preferences_partial(self):
+        """Test updating only startup email global toggle."""
+        url = reverse('startups:email-preferences-update')
+        
+        data = {
+            'enable_email': False
+        }
+        
+        response = self.client.patch(url, data, format='json')
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data['enable_email'])
+        
+        pref = UserNotificationPreference.objects.get(user=self.startup_user)
+        self.assertFalse(pref.enable_email)
+
+    def test_update_startup_email_preferences_invalid_frequency(self):
+        """Test updating startup email preferences with invalid frequency."""
+        url = reverse('startups:email-preferences-update')
+        
+        # Get a notification type to update
+        notification_type = NotificationType.objects.first()
+        
+        data = {
+            'enable_email': True,
+            'type_preferences': [
+                {
+                    'notification_type_id': notification_type.id,
+                    'frequency': 'invalid_frequency'
+                }
+            ]
+        }
+        
+        response = self.client.patch(url, data, format='json')
+        
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('error', response.data)
+        self.assertIn('errors', response.data)
+
+    def test_update_startup_email_preferences_invalid_type_id(self):
+        """Test updating startup email preferences with invalid notification type ID."""
+        url = reverse('startups:email-preferences-update')
+        
+        invalid_id = 99999
+        
+        data = {
+            'enable_email': True,
+            'type_preferences': [
+                {
+                    'notification_type_id': invalid_id,
+                    'frequency': 'immediate'
+                }
+            ]
+        }
+        
+        response = self.client.patch(url, data, format='json')
+        
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('errors', response.data)
+        # Check if at least one error contains 'not found' message
+        found_error = False
+        for error in response.data.get('errors', []):
+            if 'error' in error and 'not found' in error['error']:
+                found_error = True
+                break
+        self.assertTrue(found_error, "Expected to find an error with 'not found' message")
+
+    def test_non_startup_user_access(self):
+        """Test that non-startup users can't access startup preferences."""
+        # Create a non-startup user (regular user without a startup)
+        non_startup_user = UserFactory()
+        non_startup_token = Token.objects.create(user=non_startup_user)
+        
+        client = APIClient()
+        client.force_authenticate(user=non_startup_user, token=non_startup_token)
+        
+        # Try to access startup endpoints
+        get_url = reverse('startups:preferences')
+        response = client.get(get_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN,
+                        'Startup preferences GET endpoint should require startup role')
+        
+        email_prefs_url = reverse('startups:email-preferences-get')
+        response = client.get(email_prefs_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN,
+                        'Startup email preferences GET endpoint should require startup role')
+        
+        response = client.patch(reverse('startups:email-preferences-update'), {}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN,
+                        'Startup email preferences PATCH endpoint should require startup role')
+
+    def test_startup_email_preferences_unauthorized(self):
+        """Test that unauthorized users can't access startup email preferences."""
+        client = APIClient()
+        
+        get_url = reverse('startups:email-preferences-get')
+        response = client.get(get_url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED,
+                        'Startup email preferences GET endpoint should require authentication')
+        
+        patch_url = reverse('startups:email-preferences-update')
+        response = client.patch(patch_url, {}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED,
+                        'Startup email preferences PATCH endpoint should require authentication')

--- a/tests/elasticsearch/test_startup_elasticsearch.py
+++ b/tests/elasticsearch/test_startup_elasticsearch.py
@@ -43,7 +43,7 @@ class StartupElasticsearchTests(BaseElasticsearchAPITestCase):
         """
         Ensure that an empty search query returns all startups in the index.
         """
-        url = reverse('startup-list')
+        url = reverse('startups:startups-list')
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 2)
@@ -54,7 +54,7 @@ class StartupElasticsearchTests(BaseElasticsearchAPITestCase):
         """
         Ensure that searching for a non-existent company name returns no results.
         """
-        url = reverse('startup-list')
+        url = reverse('startups:startups-list')
         response = self.client.get(url, {'search': 'Nonexistent Company'})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 0)
@@ -65,7 +65,7 @@ class StartupElasticsearchTests(BaseElasticsearchAPITestCase):
         """
         Ensure that filtering by stage and location returns the correct startup.
         """
-        url = reverse('startup-list')
+        url = reverse('startups:startups-list')
         response = self.client.get(url, {
             'stage': Stage.MVP,
             'location.country': 'DE'

--- a/tests/startups/test_api.py
+++ b/tests/startups/test_api.py
@@ -25,7 +25,7 @@ class StartupAPITests(BaseAPITestCase):
             'founded_year': 2020,
             'email': 'great@example.com',
         }
-        self.url = reverse('startup-list')
+        self.url = reverse('startups:startups-list')
 
     @patch("users.permissions.IsStartupUser.has_permission", return_value=True)
     @patch("users.permissions.IsStartupUser.has_object_permission", return_value=True)
@@ -62,7 +62,7 @@ class StartupAPITests(BaseAPITestCase):
             industry=self.industry,
             location=self.location
         )
-        url = reverse('startup-list')
+        url = reverse('startups:startups-list')
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertGreaterEqual(len(response.data), 1)
@@ -134,7 +134,7 @@ class StartupAPITests(BaseAPITestCase):
             user=self.user, company_name='DetailStartup',
             industry=self.industry, location=self.location
         )
-        url_detail = reverse('startup-detail', args=[startup.pk])
+        url_detail = reverse('startups:startups-detail', args=[startup.pk])
         response = self.client.get(url_detail)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['company_name'], 'DetailStartup')
@@ -151,7 +151,7 @@ class StartupAPITests(BaseAPITestCase):
             user=self.user, company_name='OldName',
             industry=self.industry, location=self.location
         )
-        url_detail = reverse('startup-detail', args=[startup.pk])
+        url_detail = reverse('startups:startups-detail', args=[startup.pk])
         data = {
             'company_name': 'UpdatedName',
             'team_size': 20,
@@ -177,7 +177,7 @@ class StartupAPITests(BaseAPITestCase):
             user=self.user, company_name='PartialUpdate',
             industry=self.industry, location=self.location
         )
-        url_detail = reverse('startup-detail', args=[startup.pk])
+        url_detail = reverse('startups:startups-detail', args=[startup.pk])
         data = {'company_name': 'PartialUpdatedName'}
         response = self.client.patch(url_detail, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -195,7 +195,7 @@ class StartupAPITests(BaseAPITestCase):
             user=self.user, company_name='ValidName',
             industry=self.industry, location=self.location
         )
-        url_detail = reverse('startup-detail', args=[startup.pk])
+        url_detail = reverse('startups:startups-detail', args=[startup.pk])
         data = {'company_name': ''}
         response = self.client.patch(url_detail, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -213,7 +213,7 @@ class StartupAPITests(BaseAPITestCase):
             user=self.user, company_name='ToDelete',
             industry=self.industry, location=self.location
         )
-        url_detail = reverse('startup-detail', args=[startup.pk])
+        url_detail = reverse('startups:startups-detail', args=[startup.pk])
         response = self.client.delete(url_detail)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(Startup.objects.filter(pk=startup.pk).exists())
@@ -271,7 +271,7 @@ class StartupAPITests(BaseAPITestCase):
             industry=self.industry,
             location=self.location
         )
-        url_detail = reverse('startup-detail', args=[startup.pk])
+        url_detail = reverse('startups:startups-detail', args=[startup.pk])
         data = {
             'company_name': 'NewName',
             'team_size': 30,

--- a/tests/startups/test_api_create.py
+++ b/tests/startups/test_api_create.py
@@ -19,7 +19,7 @@ class StartupCreateAPITests(BaseCompanyCreateAPITestCase):
         )
         self.client = APIClient(enforce_csrf_checks=False)
         authenticate_client(self.client, self.user_for_creation)
-        self.url = reverse('startup-list')
+        self.url = reverse('startups:startups-list')
         self.industry, _ = Industry.objects.get_or_create(name="Testable Industry")
         self.location, _ = Location.objects.get_or_create(country="US")
 

--- a/tests/startups/test_startup_preferences.py
+++ b/tests/startups/test_startup_preferences.py
@@ -24,7 +24,7 @@ class StartupNotificationPreferencesAPITests(APITestCase):
 
     def test_get_preferences_creates_defaults(self):
         """GET initializes default channel flags and seeds per-type preferences."""
-        url = reverse('startup-preferences')
+        url = reverse('startups:preferences')
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertIn('enable_in_app', resp.data)
@@ -36,9 +36,9 @@ class StartupNotificationPreferencesAPITests(APITestCase):
 
     def test_patch_channel_preferences(self):
         """PATCH updates enable_in_app/email/push channel toggles."""
-        _ = self.client.get(reverse('startup-preferences'))
+        _ = self.client.get(reverse('startups:preferences'))
 
-        url = reverse('startup-preferences')
+        url = reverse('startups:preferences')
         payload = {
             'enable_in_app': True,
             'enable_email': False,
@@ -52,13 +52,13 @@ class StartupNotificationPreferencesAPITests(APITestCase):
 
     def test_update_type_preference_valid(self):
         """PATCH per-type preference sets a valid frequency value successfully."""
-        pref_resp = self.client.get(reverse('startup-preferences'))
+        pref_resp = self.client.get(reverse('startups:preferences'))
         self.assertEqual(pref_resp.status_code, status.HTTP_200_OK)
 
         pref = UserNotificationPreference.objects.get(user=self.user)
         type_pref = pref.type_preferences.first()
 
-        url = reverse('startup-preferences-update-type')
+        url = reverse('startups:preferences-update-type')
         payload = {
             'notification_type_id': type_pref.notification_type.id,
             'frequency': 'daily_digest',
@@ -69,11 +69,11 @@ class StartupNotificationPreferencesAPITests(APITestCase):
 
     def test_update_type_preference_invalid_frequency(self):
         """Return 400 when frequency is invalid for a type preference update."""
-        _ = self.client.get(reverse('startup-preferences'))
+        _ = self.client.get(reverse('startups:preferences'))
         pref = UserNotificationPreference.objects.get(user=self.user)
         type_pref = pref.type_preferences.first()
 
-        url = reverse('startup-preferences-update-type')
+        url = reverse('startups:preferences-update-type')
         resp = self.client.patch(
             url,
             {'notification_type_id': type_pref.notification_type.id, 'frequency': 'invalid_freq'},
@@ -84,9 +84,9 @@ class StartupNotificationPreferencesAPITests(APITestCase):
 
     def test_update_type_preference_invalid_type_id_non_integer(self):
         """Return 400 when notification_type_id is not an integer."""
-        _ = self.client.get(reverse('startup-preferences'))
+        _ = self.client.get(reverse('startups:preferences'))
 
-        url = reverse('startup-preferences-update-type')
+        url = reverse('startups:preferences-update-type')
         resp = self.client.patch(
             url,
             {'notification_type_id': 'abc', 'frequency': 'immediate'},
@@ -98,11 +98,11 @@ class StartupNotificationPreferencesAPITests(APITestCase):
 
     def test_update_type_preference_not_found(self):
         """Return 404 when the user's seeded preferences do not include the requested type."""
-        _ = self.client.get(reverse('startup-preferences'))
+        _ = self.client.get(reverse('startups:preferences'))
 
         another_type = NotificationTypeFactory()
 
-        url = reverse('startup-preferences-update-type')
+        url = reverse('startups:preferences-update-type')
         resp = self.client.patch(
             url,
             {'notification_type_id': another_type.id, 'frequency': 'immediate'},
@@ -117,11 +117,11 @@ class StartupNotificationPreferencesAPITests(APITestCase):
         client = APIClient()
         authenticate_client(client, other_user)
 
-        list_url = reverse('startup-preferences')
+        list_url = reverse('startups:preferences')
         resp = client.get(list_url)
         self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
 
-        update_url = reverse('startup-preferences-update-type')
+        update_url = reverse('startups:preferences-update-type')
         resp = client.patch(update_url, {}, format='json')
         self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
 


### PR DESCRIPTION
In this task, I completed the implementation of the Email Notification Preferences API.
Startups can now:
    * View their current email notification preferences
    * Toggle email notifications globally on/off
    * Set per-notification-type frequency preferences (immediate, daily, weekly, or disabled


The API properly validates inputs and provides clear error responses. 
Also, I seeded our types of notifications: ‘startup_saved’, ’ project_followed', 'message_received', 'activity_summarized’.

All tests passed:
![Image 31 08 2025 at 9 38 PM](https://github.com/user-attachments/assets/dc6514d4-1671-48bb-88b9-ca09c86be885)