### PR TITLE
Issue investor profile

### DIFF
--- a/investors/serializers/investor.py
+++ b/investors/serializers/investor.py
@@ -179,4 +179,10 @@ class ViewedStartupSerializer(serializers.ModelSerializer):
     class Meta:
         model = ViewedStartup
         fields = ["id", "startup_id", "company_name", "viewed_at"]
-        
+
+class InvestorListSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Investor
+        fields = [
+            'id', 'company_name', 'industry', 'stage', 'team_size', 'fund_size'
+        ]        

--- a/investors/urls.py
+++ b/investors/urls.py
@@ -5,10 +5,13 @@ from django.urls import path
 from .views import (
     ViewedStartupListView,
     ViewedStartupCreateView,
-    ViewedStartupClearView
+    ViewedStartupClearView,
+    InvestorListView,
+    InvestorDetailView
 )
 from investors.views import InvestorViewSet, SavedStartupViewSet, SaveStartupView
 from investors.views_saved import InvestorSavedStartupsList, UnsaveStartupView
+
 
 router = DefaultRouter()
 router.register(r'saved', SavedStartupViewSet, basename='saved-startup')
@@ -32,5 +35,11 @@ urlpatterns = [
 
     # DELETE /api/v1/investors/startups/<startup_id>/unsave/
     path("startups/<int:startup_id>/unsave/", UnsaveStartupView.as_view(), name="startup-unsave"),
+    
+    # GET /api/v1/investors/
+    path("investors/", InvestorListView.as_view(), name="investor-list"),
+
+    # GET /api/v1/investors/{id}/
+    path("investors/<int:pk>/", InvestorDetailView.as_view(), name="investor-detail")
 ] + router.urls
 

--- a/investors/views.py
+++ b/investors/views.py
@@ -337,13 +337,17 @@ class InvestorListView(generics.ListAPIView):
             queryset = queryset.filter(fund_size__lte=max_fund_size)
 
         # --- Sorting ---
-        ordering = params.get("ordering")  # etc.: ?ordering=fund_size or ?ordering=-team_size
+        allowed_ordering_fields = ["company_name", "fund_size", "team_size", "stage"]
+        ordering = params.get("ordering")
+
         if ordering:
-            queryset = queryset.order_by(ordering)
+            field_name = ordering.lstrip("-")
+            if field_name in allowed_ordering_fields:
+                queryset = queryset.order_by(ordering)
+            else:
+                queryset = queryset.order_by("company_name")
         else:
             queryset = queryset.order_by("company_name")
-
-        return queryset
 
 
 class InvestorDetailView(generics.RetrieveAPIView):

--- a/investors/views.py
+++ b/investors/views.py
@@ -303,54 +303,54 @@ class SaveStartupView(CookieJWTProtectedView):
                 return Response(SavedStartupSerializer(obj).data, status=status.HTTP_200_OK)
             raise
 
-    class InvestorListView(generics.ListAPIView):
-        """
-        Returns a list of all investors with filtering support.
-        Only authenticated users can access.
-        """
-        serializer_class = InvestorListSerializer
-        permission_classes = [permissions.IsAuthenticated]
+class InvestorListView(generics.ListAPIView):
+    """
+    Returns a list of all investors with filtering support.
+    Only authenticated users can access.
+    """
+    serializer_class = InvestorListSerializer
+    permission_classes = [permissions.IsAuthenticated]
 
-        def get_queryset(self):
-            queryset = Investor.objects.all()
-            params = self.request.query_params
-
-            # --- Filters ---
-            industry = params.get("industry")
-            stage = params.get("stage")
-            min_team_size = params.get("min_team_size")
-            max_team_size = params.get("max_team_size")
-            min_fund_size = params.get("min_fund_size")
-            max_fund_size = params.get("max_fund_size")
-
-            if industry:
-                queryset = queryset.filter(industry__name__icontains=industry)
-            if stage:
-                queryset = queryset.filter(stage=stage)
-            if min_team_size:
-                queryset = queryset.filter(team_size__gte=min_team_size)
-            if max_team_size:
-                queryset = queryset.filter(team_size__lte=max_team_size)
-            if min_fund_size:
-                queryset = queryset.filter(fund_size__gte=min_fund_size)
-            if max_fund_size:
-                queryset = queryset.filter(fund_size__lte=max_fund_size)
-
-            # --- Sorting ---
-            ordering = params.get("ordering")  # etc.: ?ordering=fund_size or ?ordering=-team_size
-            if ordering:
-                queryset = queryset.order_by(ordering)
-            else:
-                queryset = queryset.order_by("company_name")
-
-            return queryset
-
-
-    class InvestorDetailView(generics.RetrieveAPIView):
-        """
-        Returns a single investor profile.
-        Only authenticated users can access.
-        """
+    def get_queryset(self):
         queryset = Investor.objects.all()
-        serializer_class = InvestorSerializer
-        permission_classes = [permissions.IsAuthenticated]
+        params = self.request.query_params
+
+        # --- Filters ---
+        industry = params.get("industry")
+        stage = params.get("stage")
+        min_team_size = params.get("min_team_size")
+        max_team_size = params.get("max_team_size")
+        min_fund_size = params.get("min_fund_size")
+        max_fund_size = params.get("max_fund_size")
+
+        if industry:
+            queryset = queryset.filter(industry__name__icontains=industry)
+        if stage:
+            queryset = queryset.filter(stage=stage)
+        if min_team_size:
+            queryset = queryset.filter(team_size__gte=min_team_size)
+        if max_team_size:
+            queryset = queryset.filter(team_size__lte=max_team_size)
+        if min_fund_size:
+            queryset = queryset.filter(fund_size__gte=min_fund_size)
+        if max_fund_size:
+            queryset = queryset.filter(fund_size__lte=max_fund_size)
+
+        # --- Sorting ---
+        ordering = params.get("ordering")  # etc.: ?ordering=fund_size or ?ordering=-team_size
+        if ordering:
+            queryset = queryset.order_by(ordering)
+        else:
+            queryset = queryset.order_by("company_name")
+
+        return queryset
+
+
+class InvestorDetailView(generics.RetrieveAPIView):
+    """
+    Returns a single investor profile.
+    Only authenticated users can access.
+    """
+    queryset = Investor.objects.all()
+    serializer_class = InvestorSerializer
+    permission_classes = [permissions.IsAuthenticated]

--- a/investors/views.py
+++ b/investors/views.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from investors.models import Investor, SavedStartup
 from investors.permissions import IsSavedStartupOwner
-from investors.serializers.investor import InvestorSerializer, SavedStartupSerializer, ViewedStartupSerializer
+from investors.serializers.investor import InvestorSerializer, SavedStartupSerializer, ViewedStartupSerializer, InvestorListSerializer
 from investors.serializers.investor_create import InvestorCreateSerializer
 from django.shortcuts import get_object_or_404
 from .models import ViewedStartup
@@ -17,6 +17,8 @@ from users.cookie_jwt import CookieJWTAuthentication
 from users.permissions import IsInvestor, CanCreateCompanyPermission, IsAuthenticatedOr401
 from startups.models import Startup
 from users.views.base_protected_view import CookieJWTProtectedView
+from rest_framework import generics, permissions
+from django.db.models import Q
 
 logger = logging.getLogger(__name__)
 
@@ -300,3 +302,55 @@ class SaveStartupView(CookieJWTProtectedView):
                 obj = SavedStartup.objects.get(investor=request.user.investor, startup=startup)
                 return Response(SavedStartupSerializer(obj).data, status=status.HTTP_200_OK)
             raise
+
+    class InvestorListView(generics.ListAPIView):
+        """
+        Returns a list of all investors with filtering support.
+        Only authenticated users can access.
+        """
+        serializer_class = InvestorListSerializer
+        permission_classes = [permissions.IsAuthenticated]
+
+        def get_queryset(self):
+            queryset = Investor.objects.all()
+            params = self.request.query_params
+
+            # --- Filters ---
+            industry = params.get("industry")
+            stage = params.get("stage")
+            min_team_size = params.get("min_team_size")
+            max_team_size = params.get("max_team_size")
+            min_fund_size = params.get("min_fund_size")
+            max_fund_size = params.get("max_fund_size")
+
+            if industry:
+                queryset = queryset.filter(industry__name__icontains=industry)
+            if stage:
+                queryset = queryset.filter(stage=stage)
+            if min_team_size:
+                queryset = queryset.filter(team_size__gte=min_team_size)
+            if max_team_size:
+                queryset = queryset.filter(team_size__lte=max_team_size)
+            if min_fund_size:
+                queryset = queryset.filter(fund_size__gte=min_fund_size)
+            if max_fund_size:
+                queryset = queryset.filter(fund_size__lte=max_fund_size)
+
+            # --- Sorting ---
+            ordering = params.get("ordering")  # etc.: ?ordering=fund_size or ?ordering=-team_size
+            if ordering:
+                queryset = queryset.order_by(ordering)
+            else:
+                queryset = queryset.order_by("company_name")
+
+            return queryset
+
+
+    class InvestorDetailView(generics.RetrieveAPIView):
+        """
+        Returns a single investor profile.
+        Only authenticated users can access.
+        """
+        queryset = Investor.objects.all()
+        serializer_class = InvestorSerializer
+        permission_classes = [permissions.IsAuthenticated]

--- a/tests/investors/test_investor.py
+++ b/tests/investors/test_investor.py
@@ -28,7 +28,7 @@ class InvestorAPITestCase(APITestCase):
         User = get_user_model()
         self.user = User.objects.create_user(email="test@test.com", password="password123")
 
-        self.industry = Industry.objects.create(name="Tech")
+        self.industry = Industry.objects.create(name="Fintech")
 
         self.location = Location.objects.create(
             country="PL", 

--- a/tests/investors/test_investor.py
+++ b/tests/investors/test_investor.py
@@ -4,24 +4,34 @@ from rest_framework import status
 from users.models import User
 from investors.models import Investor
 from startups.models import Industry, Location
+from django.contrib.auth import get_user_model
+
 
 class InvestorAPITestCase(APITestCase):
 
     def setUp(self):
-        self.user = User.objects.create_user(email="test@test.com", password="pass1234")
-        self.client.login(email="test@test.com", password="pass1234")
+        User = get_user_model()
+        self.user = User.objects.create_user(email="test@test.com", password="password123")
 
-        industry = Industry.objects.create(name="Fintech")
-        location = Location.objects.create(name="Warsaw")
+        self.industry = Industry.objects.create(name="Tech")
+
+        self.location = Location.objects.create(
+            country="PL", 
+            city="Warsaw", 
+            region="Mazovia"
+        )
+
         self.investor = Investor.objects.create(
             user=self.user,
-            industry=industry,
-            location=location,
-            company_name="Fintech Capital",
-            stage="MVP",
-            team_size=15,
-            fund_size=1000000
+            company_name="Fintech",
+            industry=self.industry,
+            location=self.location,
+            fund_size=1000000,
+            team_size=10,
+            stage="Seed",
+            founded_year=2020,
         )
+        self.client.force_authenticate(user=self.user)
 
     def test_list_investors(self):
         url = reverse("investor-list")
@@ -33,10 +43,10 @@ class InvestorAPITestCase(APITestCase):
         url = reverse("investor-list") + "?industry=Fintech"
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()[0]["company_name"], "Fintech Capital")
+        self.assertEqual(response.json()[0]["company_name"], "Fintech")
 
     def test_investor_detail(self):
         url = reverse("investor-detail", args=[self.investor.id])
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["company_name"], "Fintech Capital")
+        self.assertEqual(response.json()["company_name"], "Fintech")

--- a/tests/investors/test_investor.py
+++ b/tests/investors/test_investor.py
@@ -8,8 +8,23 @@ from django.contrib.auth import get_user_model
 
 
 class InvestorAPITestCase(APITestCase):
+    """
+    TestCase for Investor API endpoints.
+
+    Includes tests for listing investors, filtering by industry,
+    and retrieving investor details.
+    """
 
     def setUp(self):
+        """
+        Set up test data for Investor API tests.
+
+        Creates:
+        - A test user
+        - An industry
+        - A location
+        - An investor linked to the user, industry, and location
+        """
         User = get_user_model()
         self.user = User.objects.create_user(email="test@test.com", password="password123")
 
@@ -34,18 +49,34 @@ class InvestorAPITestCase(APITestCase):
         self.client.force_authenticate(user=self.user)
 
     def test_list_investors(self):
+        """
+        Test that the investor list endpoint returns a successful response
+        and at least one investor.
+        """
         url = reverse("investor-list")
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertGreaterEqual(len(response.json()), 1)
 
     def test_filter_investors_by_industry(self):
+        """
+        Test filtering investors by industry.
+
+        Ensures that the response contains only investors with the
+        specified industry and that the company_name matches.
+        """
         url = reverse("investor-list") + "?industry=Fintech"
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()[0]["company_name"], "Fintech")
 
     def test_investor_detail(self):
+        """
+        Test retrieving the detail of a specific investor.
+
+        Ensures that the response contains the correct investor data
+        including the company_name.
+        """
         url = reverse("investor-detail", args=[self.investor.id])
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/tests/investors/test_investor.py
+++ b/tests/investors/test_investor.py
@@ -1,0 +1,42 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
+from users.models import User
+from investors.models import Investor
+from startups.models import Industry, Location
+
+class InvestorAPITestCase(APITestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_user(email="test@test.com", password="pass1234")
+        self.client.login(email="test@test.com", password="pass1234")
+
+        industry = Industry.objects.create(name="Fintech")
+        location = Location.objects.create(name="Warsaw")
+        self.investor = Investor.objects.create(
+            user=self.user,
+            industry=industry,
+            location=location,
+            company_name="Fintech Capital",
+            stage="MVP",
+            team_size=15,
+            fund_size=1000000
+        )
+
+    def test_list_investors(self):
+        url = reverse("investor-list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertGreaterEqual(len(response.json()), 1)
+
+    def test_filter_investors_by_industry(self):
+        url = reverse("investor-list") + "?industry=Fintech"
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()[0]["company_name"], "Fintech Capital")
+
+    def test_investor_detail(self):
+        url = reverse("investor-detail", args=[self.investor.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["company_name"], "Fintech Capital")


### PR DESCRIPTION
### Implementing Viewing Functionality for Investor Profile
**Enable users to view list of investors and investors profiles through a robust and secure API**
**1) API Endpoints**
`GET /api/v1/investors/` - List visible investor profiles
`GET /api/v1/investors/{id}/` - View details of a specific startup profile
**2) Filtering Support**
Support query parameters such as:
`industry=Fintech`
`min_team_size=10`
**3) Sorting Support**
Support sorting by fields such as:
`?ordering=company_name`
`?ordering=fund_size`
`?ordering=team_size`
`?ordering=stage`
**4) Permissions**
Only authenticated users can access these endpoints.
**5) Testing**